### PR TITLE
Add hooks for extending the cached content functionality

### DIFF
--- a/hm-the-cached-content.php
+++ b/hm-the-cached-content.php
@@ -165,6 +165,13 @@ namespace {
 				'used_blocks'    => $used_blocks,
 			];
 
+			/**
+			 * Modify the cached data used to reconstitute this content from cache.
+			 *
+			 * @param [] $data Data to be cached.
+			 */
+			$data = apply_filters( 'cached_content_data', $data );
+
 			set_transient( $cache_key, $data, $expiry );
 
 			// Restore cached globals.
@@ -204,6 +211,13 @@ namespace {
 				}
 			}
 		}
+
+		/**
+		 * Perform additional actions when outputting cached content.
+		 *
+		 * @param [] $data Data in cache.
+		 */
+		do_action( 'cached_content_output', $data );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $data['the_content'];


### PR DESCRIPTION
Some plugins trigger actions on the content that rely on global state outside of the blocks themselves. One example is advertising plugins like Advanced Ads. This change adds a filter which can be used to extend the data stored with a post, and an action which can perform additional setup and output based on this cached data.