### PR TITLE
Add a filter around the cache key used to cache content

### DIFF
--- a/hm-the-cached-content.php
+++ b/hm-the-cached-content.php
@@ -27,7 +27,8 @@ namespace The_Cached_Content {
 		$post_id = is_int( $post )
 			? $post
 			: ( get_post( $post )->ID ?? null );
-		return 'the_cached_content_' . md5( $post_id );
+
+		return apply_filters( 'cached_content_cache_key', 'the_cached_content_' . md5( $post_id ), $post_id );
 	}
 
 	/**


### PR DESCRIPTION
This adds a filter around the value used to specify the cache key.

The specific use case is for a site where the content of a page differs from logged in users to non-logged-in users; but this could be used in any case where the cache needs to vary based on global state. 