### PR TITLE
Prepare 0.2.0 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Adds two new hooks that can be used to handle custom data like global state when rendering cached content: `cached_content_data` filter to add additional data to the cached object, and `cached_content_output` to handle this data when rendering the output.
+
 ## v0.1.0
 
 - Initial release: implement a `the_cached_content()` method for fragment-caching page content (default 5 minutes), and automatically restore all block-enqueued styles, scripts, and inline CSS when cached content is served.

--- a/hm-the-cached-content.php
+++ b/hm-the-cached-content.php
@@ -3,7 +3,7 @@
  * Plugin Name: The_Cached_Content()
  * Plugin Description: Provides a template function for fragment-caching the_content() without breaking styles.
  * Author: Human Made
- * Version: 0.1.0
+ * Version: 0.2.0
  * Author URI: https://humanmade.com/
  */
 


### PR DESCRIPTION
Bumps version number to 0.2.0 and updates changelog.

This release includes #3 and #4.